### PR TITLE
해시태그 서비스 구현

### DIFF
--- a/src/main/java/com/study/blog/controller/PostController.java
+++ b/src/main/java/com/study/blog/controller/PostController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -40,8 +41,10 @@ public class PostController {
 
     @PostMapping(value = "/save", produces = "application/json;charset=UTF-8")
     @ResponseBody
-    public ResponseEntity<Map<String, String>> savePost(@RequestParam(value = "image", required = false)MultipartFile file,
-                                                        final PostRequest postRequest){
+    public ResponseEntity<Map<String, String>> savePost(
+            @RequestParam(value = "image", required = false)MultipartFile file,
+            final PostRequest postRequest,
+            @RequestParam(value = "tagNames",required = false) List<String> tagNames){
         Map<String,String> response = new HashMap<>();
         String saveFileName = null;
         try {
@@ -52,7 +55,7 @@ public class PostController {
         }
         // 이미지 파일이 없으면 default.gif 로 썸네일 잡음
         postRequest.setThumbnail(Objects.requireNonNullElse(saveFileName, "default.gif"));
-        Long id = postService.savePost(postRequest);
+        Long id = postService.savePost(postRequest,tagNames);
         response.put("msg","포스트가 저장되었습니다.");
         response.put("id", String.valueOf(id));
         return ResponseEntity.ok(response);
@@ -73,8 +76,10 @@ public class PostController {
 
     @PostMapping("/update")
     @ResponseBody
-    public ResponseEntity<Map<String,String>> updatePost(@RequestParam(value = "image", required = false)MultipartFile file,
-                                        final PostRequest postRequest) {
+    public ResponseEntity<Map<String,String>> updatePost(
+            @RequestParam(value = "image", required = false)MultipartFile file,
+            final PostRequest postRequest,
+            @RequestParam(value = "tagNames",required = false) List<String> tagNames) {
         Map<String,String> response = new HashMap<>();
         String saveFileName = null;
         try {
@@ -92,9 +97,9 @@ public class PostController {
         } else { // 이미지 파일이 없으면 썸네일 그대로 냅둬야함
             postRequest.setThumbnail(originThumbnail);
         }
-        postService.updatePost(postRequest);
+        Long id = postService.updatePost(postRequest, tagNames);
         response.put("msg","포스트가 수정되었습니다.");
-        response.put("id", String.valueOf(postRequest.getId()));
+        response.put("id", String.valueOf(id));
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/study/blog/domain/Hashtag.java
+++ b/src/main/java/com/study/blog/domain/Hashtag.java
@@ -1,0 +1,16 @@
+package com.study.blog.domain;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Hashtag {
+    private Long id;
+    private String name;
+    @Builder
+    public Hashtag(Long id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+}

--- a/src/main/java/com/study/blog/domain/PostTag.java
+++ b/src/main/java/com/study/blog/domain/PostTag.java
@@ -1,0 +1,19 @@
+package com.study.blog.domain;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PostTag {
+    private Long id;
+    private Long postId;
+    private Long tagId;
+
+    @Builder
+    public PostTag(Long id, Long postId, Long tagId) {
+        this.id = id;
+        this.postId = postId;
+        this.tagId = tagId;
+    }
+}

--- a/src/main/java/com/study/blog/dto/SearchDto.java
+++ b/src/main/java/com/study/blog/dto/SearchDto.java
@@ -1,0 +1,10 @@
+package com.study.blog.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class SearchDto {
+    private Long tagId; //해시태그 PK
+}

--- a/src/main/java/com/study/blog/mapper/HashtagMapper.java
+++ b/src/main/java/com/study/blog/mapper/HashtagMapper.java
@@ -1,0 +1,15 @@
+package com.study.blog.mapper;
+
+import com.study.blog.domain.Hashtag;
+import org.apache.ibatis.annotations.Mapper;
+
+import java.util.Optional;
+
+@Mapper
+public interface HashtagMapper {
+    int save(Hashtag hashtag);
+
+    Hashtag findByName(String name);
+
+    void deleteByName(String name);
+}

--- a/src/main/java/com/study/blog/mapper/PostMapper.java
+++ b/src/main/java/com/study/blog/mapper/PostMapper.java
@@ -1,6 +1,7 @@
 package com.study.blog.mapper;
 import com.study.blog.domain.post.PostRequest;
 import com.study.blog.domain.post.PostResponse;
+import com.study.blog.dto.SearchDto;
 import org.apache.ibatis.annotations.Mapper;
 
 import java.util.List;
@@ -38,4 +39,10 @@ public interface PostMapper {
      */
     List<PostResponse> findAll();
 
+    /**
+     * 해시태그에 관련된 게시글 리스트 조회
+     * @param searchDto - 해시태그 (나중에 추가될 검색파라미터들)
+     * @return - 게시글 리스트
+     */
+    List<PostResponse> findAllByHashtag(SearchDto searchDto);
 }

--- a/src/main/java/com/study/blog/mapper/PostTagMapper.java
+++ b/src/main/java/com/study/blog/mapper/PostTagMapper.java
@@ -1,0 +1,20 @@
+package com.study.blog.mapper;
+
+import com.study.blog.domain.PostTag;
+import org.apache.ibatis.annotations.Mapper;
+
+import java.util.List;
+import java.util.Map;
+
+@Mapper
+public interface PostTagMapper {
+    void save(PostTag postTag);
+
+    void deleteByPostId(Long postId);
+
+    List<String> findNameByPostId(Long postId);
+
+    void deleteByPostIdAndTagName(Map<String,Object> map);
+
+    int countByTagName(String tagName);
+}

--- a/src/main/java/com/study/blog/service/HashtagService.java
+++ b/src/main/java/com/study/blog/service/HashtagService.java
@@ -1,0 +1,84 @@
+package com.study.blog.service;
+
+import com.study.blog.domain.Hashtag;
+import com.study.blog.domain.PostTag;
+import com.study.blog.mapper.HashtagMapper;
+import com.study.blog.mapper.PostTagMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.*;
+
+@Service
+@RequiredArgsConstructor
+public class HashtagService {
+    private final HashtagMapper hashtagMapper;
+    private final PostTagMapper postTagMapper;
+
+
+    public void saveHashtag(List<String>tagNames, Long postId) {
+        if(tagNames == null || tagNames.isEmpty()){
+            return;
+        }
+        List<Long> tagIdList = new ArrayList<>();
+        Hashtag newTag = null;
+        for (String tagName : tagNames) {
+            Hashtag findHashtag = hashtagMapper.findByName(tagName);
+            if(findHashtag == null) {
+                newTag = Hashtag.builder().name(tagName).build();
+                hashtagMapper.save(newTag);
+                tagIdList.add(newTag.getId());
+            } else {
+                tagIdList.add(findHashtag.getId());
+            }
+        }
+        savePostTag(tagIdList,postId);
+    }
+
+    private void savePostTag(List<Long> tagIdList, Long postId) {
+        for (Long tagId : tagIdList) {
+            PostTag postTag = PostTag.builder()
+                    .postId(postId)
+                    .tagId(tagId)
+                    .build();
+            postTagMapper.save(postTag);
+        }
+    }
+
+
+    public void updateHashtag(List<String> tagNames, Long postId) {
+        if(tagNames == null || tagNames.isEmpty()) {
+            tagNames = new ArrayList<>();
+        }
+        List<String> findTagNames = postTagMapper.findNameByPostId(postId);
+        Map<String,Object> map = new HashMap<>();
+        map.put("postId",postId);
+        for (String findTagName : findTagNames) { //기존 해시태그가
+            if (!tagNames.contains(findTagName)) { //업데이트 된 태그 리스트에 존재하지 않으면
+                map.put("tagName",findTagName);
+                postTagMapper.deleteByPostIdAndTagName(map); // 삭제
+                deleteNotUsedHashtag(findTagName);
+            } else { //존재하면 중복 저장을 방지하기 위해 리스트에서 제외
+                tagNames.remove(findTagName);
+            }
+        }
+        saveHashtag(tagNames,postId);
+    }
+
+    //태그이름으로 조회해서 0이면 사용하지않으니 삭제
+    private void deleteNotUsedHashtag(String tagName) {
+        int count = postTagMapper.countByTagName(tagName);
+        if(count == 0) {
+            hashtagMapper.deleteByName(tagName);
+        }
+    }
+
+    public void deleteByPostId(Long postId) {
+        List<String> tagNames = postTagMapper.findNameByPostId(postId);
+        postTagMapper.deleteByPostId(postId);
+        for (String tagName : tagNames) {
+            deleteNotUsedHashtag(tagName);
+        }
+    }
+}

--- a/src/main/java/com/study/blog/service/PostService.java
+++ b/src/main/java/com/study/blog/service/PostService.java
@@ -12,14 +12,16 @@ import java.util.List;
 @RequiredArgsConstructor
 public class PostService {
     private final PostMapper postMapper;
-
+    private final HashtagService hashtagService;
     /**
      * 포스트 저장
      * @param postRequest - 포스트 정보
      * @return - keyGenerated 에 의해 생성된 기본키
      */
-    public Long savePost(final PostRequest postRequest) {
+    @Transactional
+    public Long savePost(final PostRequest postRequest, final List<String> tagNames) {
         postMapper.save(postRequest);
+        hashtagService.saveHashtag(tagNames,postRequest.getId());
         return postRequest.getId();
     }
 
@@ -38,8 +40,9 @@ public class PostService {
      * @return PK
      */
     @Transactional
-    public Long updatePost(final PostRequest postRequest) {
+    public Long updatePost(final PostRequest postRequest, final List<String>tagNames) {
         postMapper.update(postRequest);
+        hashtagService.updateHashtag(tagNames, postRequest.getId());
         return postRequest.getId();
     }
 
@@ -48,8 +51,10 @@ public class PostService {
      * @param id - PK
      * @return PK
      */
+    @Transactional
     public Long deletePost(final Long id) {
         postMapper.deleteById(id);
+        hashtagService.deleteByPostId(id);
         return id;
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,7 +12,7 @@ spring:
 mybatis:
   configuration:
     map-underscore-to-camel-case: true
-  type-aliases-package: com.study.blog.domain
+  type-aliases-package: com.study.blog.domain, com.study.blog.dto
   mapper-locations: classpath:mybatis/mapper/*.xml
 logging:
   level:

--- a/src/main/resources/mybatis/mapper/hashtag-mapper.xml
+++ b/src/main/resources/mybatis/mapper/hashtag-mapper.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.study.blog.mapper.HashtagMapper">
+    <insert id="save" parameterType="Hashtag" useGeneratedKeys="true" keyProperty="id">
+        insert into hashtag(name) values (#{name})
+    </insert>
+    <delete id="deleteByName" parameterType="String">
+        delete from hashtag where name = #{name}
+    </delete>
+    <select id="findByName" parameterType="String" resultType="Hashtag">
+        select * from hashtag where name = #{name};
+    </select>
+</mapper>

--- a/src/main/resources/mybatis/mapper/post-mapper.xml
+++ b/src/main/resources/mybatis/mapper/post-mapper.xml
@@ -64,4 +64,20 @@
         ORDER BY
         id DESC
     </select>
+
+    <!-- 해시태그 id로 게시글 리스트 조회 -->
+    <select id="findAllByHashtag" parameterType="SearchDto" resultType="PostResponse">
+        select
+            p.id,
+            p.title,
+            p.description,
+            p.thumbnail,
+            p.content,
+            p.view_cnt,
+            p.delete_yn,
+            p.created_date,
+            p.modified_date
+        from post p inner join post_tag pt on p.id = pt.post_id
+        where p.delete_yn = 0 and pt.tag_id = #{tagId};
+    </select>
 </mapper>

--- a/src/main/resources/mybatis/mapper/posttag-mapper.xml
+++ b/src/main/resources/mybatis/mapper/posttag-mapper.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.study.blog.mapper.PostTagMapper">
+    <sql id="postTagColumns">
+        id
+        ,post_id
+        ,tag_id
+    </sql>
+    <insert id="save" parameterType="PostTag" keyProperty="id" useGeneratedKeys="true">
+        insert into post_tag(post_id, tag_id) values (#{postId},#{tagId})
+    </insert>
+
+    <update id="deleteByPostId" parameterType="Long">
+        delete from post_tag where post_id = #{postId}
+    </update>
+
+    <select id="findNameByPostId" parameterType="Long" resultType="String">
+        select h.name
+        from post_tag pt inner join hashtag h on pt.tag_id = h.id
+        where post_id = #{postId}
+    </select>
+    <select id="countByTagName" parameterType="String" resultType="Integer">
+        select count(*) from post_tag pt inner join hashtag h on pt.tag_id = h.id
+        where h.name = #{tagName}
+    </select>
+
+    <delete id="deleteByPostIdAndTagName" parameterType="Map">
+        delete from post_tag where post_id = #{postId} and tag_id in (
+            select id from hashtag where name like #{tagName});
+    </delete>
+</mapper>

--- a/src/test/java/com/study/blog/mapper/HashtagServiceTest.java
+++ b/src/test/java/com/study/blog/mapper/HashtagServiceTest.java
@@ -1,0 +1,82 @@
+package com.study.blog.mapper;
+
+import com.study.blog.domain.Hashtag;
+import com.study.blog.domain.post.PostRequest;
+import com.study.blog.domain.post.PostResponse;
+import com.study.blog.dto.SearchDto;
+import com.study.blog.service.PostService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@SpringBootTest
+class HashtagServiceTest {
+    @Autowired HashtagMapper hashtagMapper;
+    @Autowired PostTagMapper postTagMapper;
+    @Autowired PostMapper postMapper;
+    @Autowired
+    PostService postService;
+
+    @Test
+    @DisplayName("해시태그들을 저장한다.")
+    public void save() throws Exception {
+        PostRequest postRequest = PostRequest.builder()
+                .title("test3")
+                .description("test3")
+                .content("test3")
+                .build();
+        postRequest.setThumbnail("default.gif");
+        List<String> tagNames = new ArrayList<>();
+        tagNames.add("mybatis");
+        tagNames.add("jpa");
+        tagNames.add("일상");
+        Long postId = postService.savePost(postRequest, tagNames);
+     }
+
+     @Test
+     @DisplayName("특정 해시태그 이름으로 관련된 게시물을 찾는다.")
+     public void findPostByHashtag() throws Exception {
+         //given
+         String hashtagName = "mybatis";
+         Hashtag springTag = hashtagMapper.findByName(hashtagName);
+         SearchDto searchDto = new SearchDto();
+         searchDto.setTagId(springTag.getId());
+         //when
+         List<PostResponse> springList = postMapper.findAllByHashtag(searchDto);
+         //then
+         for (PostResponse postResponse : springList) {
+             System.out.println("postResponse.getContent() = " + postResponse.getContent());
+         }
+      }
+
+      @Test
+      @DisplayName("해시태그를 수정한다.")
+      public void updateHashTag() throws Exception {
+          //given
+          PostResponse findPost = postMapper.findById(7L);
+          PostRequest postRequest = PostRequest.builder()
+                  .id(findPost.getId())
+                  .title(findPost.getTitle())
+                  .content(findPost.getContent())
+                  .description(findPost.getDescription())
+                  .build();
+          postRequest.setThumbnail("default.gif");
+          List<String> modifyTagNames = new ArrayList<>();
+          modifyTagNames.add("spring");
+          modifyTagNames.add("mybatis");
+          modifyTagNames.add("jpa");
+          //when 중복저장은 허용하지 않기때문에 안들어가고 jpa만 추가로 들어감
+            postService.updatePost(postRequest,modifyTagNames);
+          //then
+       }
+
+       @Test
+       @DisplayName("포스트를 삭제하면 사용되지 않는 해시태그도 삭제된다.")
+       public void deleteHashtag() throws Exception {
+           postService.deletePost(9L);
+        }
+}


### PR DESCRIPTION
this closes #13 
해시태그 구현을 위한 컨트롤러,서비스,매퍼,xml,DB 를 구현하였다.
뷰를 위한 CRUD 서비스만 만들어놓았고, 다음 이슈에서 뷰에 붙이는 작업을 해야한다.