### PR TITLE
OAuth2 Security 인증 사용

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ build/
 !**/src/main/**/build/
 !**/src/test/**/build/
 
+### SPRING SECURITY OAUTH2 INFO ###
+/src/main/resources/application-oauth.yml
+
 ### STS ###
 .apt_generated
 .classpath

--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,8 @@ dependencies {
 	implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:2.3.1'
 	implementation 'nz.net.ultraq.thymeleaf:thymeleaf-layout-dialect' /* Thymeleaf Layout */
 	implementation 'org.bgee.log4jdbc-log4j2:log4jdbc-log4j2-jdbc4.1:1.16' /* 쿼리문 출력 */
+	implementation 'org.springframework.security:spring-security-oauth2-client:5.7.5'
+	compileOnly "org.springframework.boot:spring-boot-starter-security"
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/study/blog/config/SecurityConfig.java
+++ b/src/main/java/com/study/blog/config/SecurityConfig.java
@@ -1,0 +1,33 @@
+package com.study.blog.config;
+
+import com.study.blog.oauth2.CustomOAuth2UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+    private final CustomOAuth2UserService customOAuth2UserService;
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf().disable()
+                .formLogin().disable()
+                .authorizeRequests()//URL별 권한 관리를 설정하는 옵션의 시작점
+                .antMatchers("/","/css/**","/images/**",
+                        "/js/**").permitAll()
+                .anyRequest().authenticated()
+                .and()
+                .logout()
+                .logoutSuccessUrl("/")
+                .and()
+                .oauth2Login()
+                .defaultSuccessUrl("/post")
+                .userInfoEndpoint().userService(customOAuth2UserService);
+        return http.build();
+    }
+}

--- a/src/main/java/com/study/blog/controller/MainController.java
+++ b/src/main/java/com/study/blog/controller/MainController.java
@@ -1,0 +1,22 @@
+package com.study.blog.controller;
+
+import com.study.blog.domain.Users;
+import com.study.blog.dto.SessionUser;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+
+import javax.servlet.http.HttpSession;
+
+@Controller
+public class MainController {
+    @GetMapping("/")
+    public String index(Model model, HttpSession session) {
+        SessionUser sessionUser = (SessionUser) session.getAttribute("user");
+        if(sessionUser != null) {
+            model.addAttribute("user",sessionUser);
+        }
+        return "index";
+    }
+}

--- a/src/main/java/com/study/blog/domain/Users.java
+++ b/src/main/java/com/study/blog/domain/Users.java
@@ -1,0 +1,35 @@
+package com.study.blog.domain;
+import com.study.blog.oauth2.Role;
+import com.study.blog.oauth2.SocialType;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class Users {
+    private Long id;
+    private String email;
+    private Role role;
+    private SocialType socialType;
+    private String socialId;
+    private String nickname;
+    private String imageUrl;
+
+    @Builder
+    public Users(Long id, String email, Role role, SocialType socialType, String socialId, String nickname, String imageUrl) {
+        this.id = id;
+        this.email = email;
+        this.role = role;
+        this.socialType = socialType;
+        this.socialId = socialId;
+        this.nickname = nickname;
+        this.imageUrl = imageUrl;
+    }
+
+    public String getRoleKey() {
+        return this.role.getKey();
+    }
+}

--- a/src/main/java/com/study/blog/dto/SessionUser.java
+++ b/src/main/java/com/study/blog/dto/SessionUser.java
@@ -1,0 +1,16 @@
+package com.study.blog.dto;
+
+import com.study.blog.domain.Users;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+public class SessionUser {
+    private final String nickname;
+    private final String image;
+
+    public SessionUser(Users user) {
+        this.nickname = user.getNickname();
+        this.image = user.getImageUrl();
+    }
+}

--- a/src/main/java/com/study/blog/mapper/UserMapper.java
+++ b/src/main/java/com/study/blog/mapper/UserMapper.java
@@ -1,0 +1,23 @@
+package com.study.blog.mapper;
+
+import com.study.blog.domain.Users;
+import com.study.blog.oauth2.SocialType;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Select;
+import org.apache.ibatis.annotations.Update;
+
+import java.util.Map;
+
+@Mapper
+public interface UserMapper {
+    @Select("select * from users where email = #{email}")
+    Users findByEmail(String email);
+
+    @Select("select * from users where social_type = #{socialType} and social_id = #{socialId}")
+    Users findBySocialTypeAndSocialId(Map<String,Object> map);
+
+    @Update("update users set name = #{name} where id=#{id}")
+    void update(Users user);
+
+    int save(Users newUser);
+}

--- a/src/main/java/com/study/blog/oauth2/CustomOAuth2User.java
+++ b/src/main/java/com/study/blog/oauth2/CustomOAuth2User.java
@@ -1,0 +1,29 @@
+package com.study.blog.oauth2;
+
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+
+import java.util.Collection;
+import java.util.Map;
+
+@Getter
+public class CustomOAuth2User extends DefaultOAuth2User {
+    private String email;
+    private Role role;
+    /**
+     * Constructs a {@code DefaultOAuth2User} using the provided parameters.
+     *
+     * @param authorities      the authorities granted to the user
+     * @param attributes       the attributes about the user
+     * @param nameAttributeKey the key used to access the user's &quot;name&quot; from
+     *                         {@link #getAttributes()}
+     */
+    public CustomOAuth2User(Collection<? extends GrantedAuthority> authorities,
+                            Map<String, Object> attributes,
+                            String nameAttributeKey,String email, Role role) {
+        super(authorities, attributes, nameAttributeKey);
+        this.email = email;
+        this.role = role;
+    }
+}

--- a/src/main/java/com/study/blog/oauth2/CustomOAuth2UserService.java
+++ b/src/main/java/com/study/blog/oauth2/CustomOAuth2UserService.java
@@ -10,7 +10,6 @@ import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserServ
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
-import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 

--- a/src/main/java/com/study/blog/oauth2/CustomOAuth2UserService.java
+++ b/src/main/java/com/study/blog/oauth2/CustomOAuth2UserService.java
@@ -1,0 +1,93 @@
+package com.study.blog.oauth2;
+
+import com.study.blog.domain.Users;
+import com.study.blog.dto.SessionUser;
+import com.study.blog.mapper.UserMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import javax.servlet.http.HttpSession;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+@RequiredArgsConstructor
+@Slf4j
+@Service
+public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+    private final UserMapper userMapper;
+    private final HttpSession httpSession;
+    private static final String NAVER = "naver";
+    private static final String KAKAO = "kakao";
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        log.info("CustomOAuth2UserService.loadUser() 실행 - OAuth2 로그인 요청 진입");
+        OAuth2UserService<OAuth2UserRequest, OAuth2User> delegate = new DefaultOAuth2UserService();
+        OAuth2User oAuth2User = delegate.loadUser(userRequest);
+
+        String registrationId = userRequest
+                .getClientRegistration().getRegistrationId();
+        SocialType socialType = getSocialType(registrationId);
+
+        String userNameAttributeName = userRequest
+                .getClientRegistration()
+                .getProviderDetails()
+                .getUserInfoEndpoint()
+                .getUserNameAttributeName();
+
+        OAuthAttributes extractAttributes = OAuthAttributes
+                .of(socialType, userNameAttributeName,
+                        oAuth2User.getAttributes());
+
+        Users createdUser = getUser(extractAttributes,socialType); //getUser 메서드로 User객체 생성후 반환
+
+        httpSession.setAttribute("user", new SessionUser(createdUser));
+
+        return new CustomOAuth2User(
+                Collections.singleton(new SimpleGrantedAuthority(createdUser.getRoleKey())),
+                oAuth2User.getAttributes(),
+                extractAttributes.getNameAttributeKey(),
+                createdUser.getEmail(),
+                createdUser.getRole());
+    }
+
+    private Users getUser(OAuthAttributes attributes, SocialType socialType) {
+        Map<String,Object> map = new HashMap<>();
+        map.put("socialType",socialType);
+        map.put("socialId",attributes.getOauth2UserInfo().getId());
+        Users findUser = userMapper.findBySocialTypeAndSocialId(map);
+        if(findUser == null) {
+            return saveUser(attributes,socialType);
+        }
+        return findUser;
+    }
+
+    private SocialType getSocialType(String registrationId) {
+        if(NAVER.equals(registrationId)) {
+            return SocialType.NAVER;
+        }
+        if(KAKAO.equals(registrationId)) {
+            return SocialType.KAKAO;
+        }
+        return SocialType.GOOGLE;
+    }
+
+    private Users saveUser(OAuthAttributes attributes, SocialType socialType) {
+        Users createdUser = attributes.toEntity(socialType, attributes.getOauth2UserInfo());
+        userMapper.save(createdUser);
+        return createdUser;
+    }
+
+
+
+}
+

--- a/src/main/java/com/study/blog/oauth2/GoogleOAuth2UserInfo.java
+++ b/src/main/java/com/study/blog/oauth2/GoogleOAuth2UserInfo.java
@@ -1,0 +1,24 @@
+package com.study.blog.oauth2;
+
+import java.util.Map;
+
+public class GoogleOAuth2UserInfo extends OAuth2UserInfo{
+    public GoogleOAuth2UserInfo(Map<String, Object> attributes) {
+        super(attributes);
+    }
+
+    @Override
+    public String getId() {
+        return (String) attributes.get("sub");
+    }
+
+    @Override
+    public String getNickname() {
+        return (String) attributes.get("name");
+    }
+
+    @Override
+    public String getImageUrl() {
+        return (String) attributes.get("picture");
+    }
+}

--- a/src/main/java/com/study/blog/oauth2/KakaoOAuth2UserInfo.java
+++ b/src/main/java/com/study/blog/oauth2/KakaoOAuth2UserInfo.java
@@ -1,0 +1,39 @@
+package com.study.blog.oauth2;
+
+import java.util.Map;
+
+public class KakaoOAuth2UserInfo extends OAuth2UserInfo{
+
+    public KakaoOAuth2UserInfo(Map<String, Object> attributes) {
+        super(attributes);
+    }
+
+    @Override
+    public String getId() {
+        return String.valueOf(attributes.get("id"));
+    }
+
+    @Override
+    public String getNickname() {
+        Map<String, Object> account = (Map<String, Object>) attributes.get("kakao_account");
+        Map<String, Object> profile = (Map<String, Object>) account.get("profile");
+
+        if (profile == null) {
+            return null;
+        }
+
+        return (String) profile.get("nickname");
+    }
+
+    @Override
+    public String getImageUrl() {
+        Map<String, Object> account = (Map<String, Object>) attributes.get("kakao_account");
+        Map<String, Object> profile = (Map<String, Object>) account.get("profile");
+
+        if (profile == null) {
+            return null;
+        }
+
+        return (String) profile.get("thumbnail_image_url");
+    }
+}

--- a/src/main/java/com/study/blog/oauth2/NaverOAuth2UserInfo.java
+++ b/src/main/java/com/study/blog/oauth2/NaverOAuth2UserInfo.java
@@ -1,0 +1,39 @@
+package com.study.blog.oauth2;
+
+import java.util.Map;
+
+public class NaverOAuth2UserInfo extends OAuth2UserInfo{
+
+    public NaverOAuth2UserInfo(Map<String,Object> attributes) {
+        super(attributes);
+    }
+
+    @Override
+    public String getId() {
+        Map<String,Object> response = (Map<String, Object>) attributes.get("response");
+        if(response == null) {
+            return null;
+        }
+        return (String) response.get("id");
+    }
+
+    @Override
+    public String getNickname() {
+        Map<String,Object> response = (Map<String, Object>) attributes.get("response");
+        if(response == null) {
+            return null;
+        }
+        return (String) response.get("nickname");
+    }
+
+    @Override
+    public String getImageUrl() {
+        Map<String, Object> response = (Map<String, Object>) attributes.get("response");
+
+        if (response == null) {
+            return null;
+        }
+
+        return (String) response.get("profile_image");
+    }
+}

--- a/src/main/java/com/study/blog/oauth2/OAuth2UserInfo.java
+++ b/src/main/java/com/study/blog/oauth2/OAuth2UserInfo.java
@@ -1,0 +1,15 @@
+package com.study.blog.oauth2;
+
+import java.util.Map;
+
+public abstract class OAuth2UserInfo {
+    protected Map<String,Object> attributes;
+
+    public OAuth2UserInfo(Map<String, Object> attributes) {
+        this.attributes = attributes;
+    }
+
+    public abstract String getId();//소셜 식별 값: 구글-sub, 카카오-id, 네이버-id
+    public abstract String getNickname();
+    public abstract String getImageUrl();
+}

--- a/src/main/java/com/study/blog/oauth2/OAuthAttributes.java
+++ b/src/main/java/com/study/blog/oauth2/OAuthAttributes.java
@@ -1,0 +1,85 @@
+package com.study.blog.oauth2;
+
+import com.study.blog.domain.Users;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.Map;
+import java.util.UUID;
+
+/*
+각 소셜에서 받아오는 데이터가 다르므로
+소셜별로 데이터를 받는 데이터를 분기 처리하는 DTO 클래스
+*/
+@Getter
+public class OAuthAttributes {
+    private String nameAttributeKey; //OAuth2 로그인 진행 시 키가 되는 필드 값, PK와 같은 의미
+    private OAuth2UserInfo oauth2UserInfo; //소셜 타입별 로그인 유저 정보(닉네임, 이메일, 프로필 사진 등등)
+
+    @Builder
+    public OAuthAttributes(String nameAttributeKey, OAuth2UserInfo oauth2UserInfo) {
+        this.nameAttributeKey = nameAttributeKey;
+        this.oauth2UserInfo = oauth2UserInfo;
+    }
+
+    /**
+     * SocialType에 맞는 메소드 호출하여 OAuthAttributes 객체 반환
+     * 파라미터 : userNameAttributesName -> OAuth2 로그인 시 키(PK)가 되는 값
+     *          attributes -> OAuth2 서비스의 유저 정보들
+     * 소셜별 of 메소드 (ofGoogle, ofKakao, ofNaver)들은 각각 소셜 로그인 API에서 제공하는
+     * 회원별 식별값(id, attributes, nameAttributeKey 를 저장 후 build
+     */
+    public static OAuthAttributes of(SocialType socialType,
+                                     String userNameAttributeName,
+                                     Map<String,Object> attributes) {
+        if(socialType == SocialType.NAVER) {
+            return ofNaver(userNameAttributeName,attributes);
+        }
+        if(socialType == SocialType.KAKAO) {
+            return ofKakao(userNameAttributeName, attributes);
+        }
+        return ofGoogle(userNameAttributeName,attributes);
+    }
+
+    public static OAuthAttributes ofNaver(String userNameAttributeName,
+                                          Map<String,Object> attributes) {
+        return OAuthAttributes.builder()
+                .nameAttributeKey(userNameAttributeName)
+                .oauth2UserInfo(new NaverOAuth2UserInfo(attributes))
+                .build();
+    }
+
+    public static OAuthAttributes ofKakao(String userNameAttributeName,
+                                          Map<String,Object> attributes) {
+        return OAuthAttributes.builder()
+                .nameAttributeKey(userNameAttributeName)
+                .oauth2UserInfo(new KakaoOAuth2UserInfo(attributes))
+                .build();
+    }
+
+    public static OAuthAttributes ofGoogle(String userNameAttributeName, Map<String, Object> attributes) {
+        return OAuthAttributes.builder()
+                .nameAttributeKey(userNameAttributeName)
+                .oauth2UserInfo(new GoogleOAuth2UserInfo(attributes))
+                .build();
+    }
+
+    /**
+     * of메소드로 OAuth2Attributes 객체가 생성되어, 유저 정보들이 담긴 OAuth2UserInfo가 소셜 타입별로 주입된 상태
+     * OAuth2UserInfo에서 socialId(식별값), nickname, imageUrl을 가져와서 build
+     * email에는 UUID로 중복 없는 랜덤 값 생성
+     * role은 GUEST로 설정
+     * @return
+     */
+    public Users toEntity(SocialType socialType, OAuth2UserInfo oauth2UserInfo) {
+        return Users.builder()
+                .socialType(socialType)
+                .socialId(oauth2UserInfo.getId())
+                .email(UUID.randomUUID() + "@socialUser.com")
+                .nickname(oauth2UserInfo.getNickname())
+                .imageUrl(oauth2UserInfo.getImageUrl())
+                .role(Role.GUEST)
+                .build();
+    }
+
+}

--- a/src/main/java/com/study/blog/oauth2/Role.java
+++ b/src/main/java/com/study/blog/oauth2/Role.java
@@ -1,0 +1,15 @@
+package com.study.blog.oauth2;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Role {
+    USER("ROLE_USER","일반 사용자"),
+    GUEST("ROLE_GUEST","손님");
+    private final String key;
+    private final String title;
+}
+

--- a/src/main/java/com/study/blog/oauth2/SocialType.java
+++ b/src/main/java/com/study/blog/oauth2/SocialType.java
@@ -1,0 +1,6 @@
+package com.study.blog.oauth2;
+
+
+public enum SocialType {
+    NAVER,KAKAO,GOOGLE;
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,6 +9,9 @@ spring:
       max-request-size: 10MB
       max-file-size: 10MB
       enabled: true
+  profiles:
+    include: oauth
+
 mybatis:
   configuration:
     map-underscore-to-camel-case: true

--- a/src/main/resources/mybatis/mapper/user-mapper.xml
+++ b/src/main/resources/mybatis/mapper/user-mapper.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.study.blog.mapper.UserMapper">
+    <insert id="save" parameterType="Users" useGeneratedKeys="true" keyProperty="id">
+        insert into users(email, role, social_type, social_id, nickname, image_url)
+        VALUES (#{email},#{role},#{socialType},#{socialId},#{nickname},#{imageUrl})
+    </insert>
+</mapper>

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>인덱스</title>
+</head>
+<body>
+  <div th:if="${user == null}">
+    <a href="/oauth2/authorization/kakao">Kakao Login</a>
+    <a href="/oauth2/authorization/google">google Login</a>
+    <a href="/oauth2/authorization/naver">naver Login</a>
+  </div>
+    <div th:if="${user != null}">
+        <span th:text="${user.getNickname()}"></span>
+        <img th:src="${user.getImage()}" alt="프로필 이미지">
+    </div>
+</body>
+</html>


### PR DESCRIPTION
this closes #18 
굳이 회원 기능을 만들기보다, OAuth2 인증 방식으로 카카오, 네이버,구글의 자원을 이용하기로 했다.
Authorization Code Grant - 권한 부여 코드 승인 방식
<img width="515" alt="image" src="https://github.com/Jeong29Hyeon/JH-BLOG/assets/104767191/d33adaeb-51f0-49a6-a1cb-427dc1d8c970">
> 위 이미지는 OAuth2에서 가장 기본이 되는 방식이며, 간편 로그인에 사용되는 'Authorization Code Grant' 방식입니다. 해당 방식의 인증 플로우를 살펴보았다.
1. Client는 Authorization Server로 접근 권한을 요청한다. 이때 요청에 보내는 파라미터에는 client_id, redirect_uri, response_type=code 가 포함되어 있다. 
2. Client로부터 접근 권한 요청을 받은 Authorization Server는 소셜로그인을 할 수 있는 로그인 창을 띄워 줍니다.
3. User(Resource Owner)는 해당 소셜 로그인 창을 통해 로그인을 진행한다.
4. Authorization Server는 User가 입력한 회원 정보가 맞는지 여부를 판단한 뒤, 권한 승인 코드(Authorization Code)를 반환하게 된다.
5. Client는 Authorization Code를 통해 Resource Server에 보호된 자원을 요청할 수 있는 AccessToken을 요청한다.
6. AccessToken을 전달받은 Client는 해당 토큰을 통해 Resource Server에 필요한 요청을 보내게 된다.
> User가 로그인 후 Authorization Server에서 Access Token을 바로 발급받는것이 아니라, Authorization Code를 반환하는 과정이 한번 더 들어간 이유는 바로 보안 때문이다. Access Token을 바로 반환받게 되면, redirect_uri를 통해 받는 방법 밖에 없는데, 이렇게 되는 경우 중요한 데이터인 Access Token이 브라우저를 통해 바로 노출된다는 위험이 있다.