### PR TITLE
댓글 Mapper, Service 구현

### DIFF
--- a/src/main/java/com/study/blog/domain/comment/CommentRequest.java
+++ b/src/main/java/com/study/blog/domain/comment/CommentRequest.java
@@ -1,0 +1,24 @@
+package com.study.blog.domain.comment;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class CommentRequest {
+    private Long id;
+    private Long postId;
+    private String content;
+    private Long userId;
+    private Long parentId; //대댓글일 시, 부모댓글의 pk를 여기에 담아 요청을 받는다.
+    private int depth; //댓글일시 1, 대댓글일시 2
+    @Builder
+    public CommentRequest(Long postId, String content, Long userId, Long parentId, int depth) {
+        this.postId = postId;
+        this.content = content;
+        this.userId = userId;
+        this.parentId = parentId;
+        this.depth = depth;
+    }
+}

--- a/src/main/java/com/study/blog/domain/comment/CommentResponse.java
+++ b/src/main/java/com/study/blog/domain/comment/CommentResponse.java
@@ -1,0 +1,20 @@
+package com.study.blog.domain.comment;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CommentResponse {
+    private Long id;
+    private Long postId;
+    private String content;
+    private Long userId;
+    private LocalDateTime createdDate;
+    private LocalDateTime modifiedDate;
+    private Long parentId; //댓글의 그룹을 확인하는 용으로, 댓글 그룹의 부모 PK를 가지게 된다.
+    private int depth; //댓글일시 1, 대댓글일시 2
+}

--- a/src/main/java/com/study/blog/mapper/CommentMapper.java
+++ b/src/main/java/com/study/blog/mapper/CommentMapper.java
@@ -1,0 +1,27 @@
+package com.study.blog.mapper;
+
+import com.study.blog.domain.comment.CommentRequest;
+import com.study.blog.domain.comment.CommentResponse;
+import org.apache.ibatis.annotations.Delete;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Select;
+import org.apache.ibatis.annotations.Update;
+import java.util.List;
+
+@Mapper
+public interface CommentMapper {
+    void save(CommentRequest commentRequest);
+
+    List<CommentResponse> findComments();
+
+    List<CommentResponse> findReplies(Long id);
+
+    @Select("select count(*) from comment where parent_id = #{id} and depth = 2")
+    int countRepliesById(Long id);
+
+    @Delete("delete from comment where id=#{id}")
+    void delete(Long id);
+
+    @Update("update comment set content = #{content} where id = #{id}")
+    void update(CommentRequest commentRequest);
+}

--- a/src/main/java/com/study/blog/service/CommentService.java
+++ b/src/main/java/com/study/blog/service/CommentService.java
@@ -1,0 +1,39 @@
+package com.study.blog.service;
+
+import com.study.blog.domain.comment.CommentRequest;
+import com.study.blog.domain.comment.CommentResponse;
+import com.study.blog.mapper.CommentMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class CommentService {
+    private final CommentMapper commentMapper;
+
+    public Long save(final CommentRequest commentRequest) {
+        commentMapper.save(commentRequest);
+        return commentRequest.getId();
+    }
+
+    public List<CommentResponse> findComments() {
+        return commentMapper.findComments();
+    }
+
+    public List<CommentResponse> findReplies(final Long id) {
+        return commentMapper.findReplies(id);
+    }
+
+    public void delete(final Long id) {
+        int count = commentMapper.countRepliesById(id);
+        if(count != 0) {
+            throw new RuntimeException("답글이 달린 댓글은 삭제할 수 없습니다.");
+        }
+        commentMapper.delete(id);
+    }
+
+    public void update(final CommentRequest commentRequest) {
+        commentMapper.update(commentRequest);
+    }
+}

--- a/src/main/resources/mybatis/mapper/comment-mapper.xml
+++ b/src/main/resources/mybatis/mapper/comment-mapper.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.study.blog.mapper.CommentMapper">
+    <insert id="save" parameterType="CommentRequest" useGeneratedKeys="true" keyProperty="id">
+        insert into comment(post_id, content, user_id, created_date, modified_date, parent_id, depth)
+        VALUES (#{postId},#{content},#{userId},NOW(),null,#{parentId},#{depth})
+    </insert>
+
+    <select id="findComments" resultType="CommentResponse">
+        select * from comment where depth = 1 order by id
+    </select>
+    <select id="findReplies" parameterType="Long" resultType="CommentResponse">
+        select * from comment where parent_id = #{id} and depth = 2 order by created_date
+    </select>
+</mapper>

--- a/src/test/java/com/study/blog/mapper/HashtagServiceTest.java
+++ b/src/test/java/com/study/blog/mapper/HashtagServiceTest.java
@@ -44,9 +44,9 @@ class HashtagServiceTest {
          String hashtagName = "mybatis";
          Hashtag springTag = hashtagMapper.findByName(hashtagName);
          SearchDto searchDto = new SearchDto();
-         searchDto.setTagId(springTag.getId());
+         searchDto.setHashtag(springTag.getName());
          //when
-         List<PostResponse> springList = postMapper.findAllByHashtag(searchDto);
+         List<PostResponse> springList = postMapper.findAll(searchDto);
          //then
          for (PostResponse postResponse : springList) {
              System.out.println("postResponse.getContent() = " + postResponse.getContent());

--- a/src/test/java/com/study/blog/service/CommentServiceTest.java
+++ b/src/test/java/com/study/blog/service/CommentServiceTest.java
@@ -1,0 +1,47 @@
+package com.study.blog.service;
+
+import com.study.blog.domain.comment.CommentRequest;
+import com.study.blog.domain.comment.CommentResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class CommentServiceTest {
+    @Autowired private CommentService commentService;
+
+    @Test
+    @DisplayName("댓글을 저장한다.")
+    public void saveComment() throws Exception {
+        //given
+        CommentRequest commentRequest = CommentRequest.builder().postId(13L).content("댓글1")
+                                        .userId(3L).parentId(0L).depth(1).build();
+        //when
+        Long savedId = commentService.save(commentRequest);
+        List<CommentResponse> comments = commentService.findComments();
+
+        //then
+        comments.stream().filter((comment)-> comment.getId().equals(savedId)).findFirst()
+                .ifPresent(comment-> System.out.println(comment.getId()));
+    }
+
+    @Test
+    @DisplayName("대댓글을 저장한다.")
+    public void saveReply() throws Exception {
+        //given
+        CommentRequest commentRequest = CommentRequest.builder().postId(13L).content("댓글1의 대댓글")
+                .userId(3L).parentId(2L).depth(2).build();
+        //when
+        Long savedId = commentService.save(commentRequest);
+        List<CommentResponse> comments = commentService.findReplies(2L);
+        //then
+        for (CommentResponse comment : comments) {
+            System.out.println(comment.getContent());
+        }
+     }
+}


### PR DESCRIPTION
기존 댓글기능만 구현하려 했지만, 블로그 특성상 대댓글이 필요하다는 생각이 들어 기존 댓글에
필요한 컬럼 + 부모댓글PK, Depth 컬럼을 추가해 댓글인지, 대댓글인지 구분을 하고, 각 부모 PK를 가진 댓글의
그룹을 지어주는 기능으로 대댓글을 구현해보았다.