### PR TITLE
댓글 기능 + 대댓글 기능 구현 (재귀쿼리 사용)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
 	implementation 'nz.net.ultraq.thymeleaf:thymeleaf-layout-dialect' /* Thymeleaf Layout */
 	implementation 'org.bgee.log4jdbc-log4j2:log4jdbc-log4j2-jdbc4.1:1.16' /* 쿼리문 출력 */
 	implementation 'org.springframework.security:spring-security-oauth2-client:5.7.5'
+	implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity5'
 	compileOnly "org.springframework.boot:spring-boot-starter-security"
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/src/main/java/com/study/blog/config/SecurityConfig.java
+++ b/src/main/java/com/study/blog/config/SecurityConfig.java
@@ -20,6 +20,7 @@ public class SecurityConfig {
                 .formLogin().disable()
                 .authorizeHttpRequests((auth)-> {
                     auth.antMatchers("/","/css/**","/error","/js/**","/post","/image/**/*","/oauth2-login").permitAll()
+                            .antMatchers("/post/write","/post/save","/post/delete","/post/update").hasRole(Role.USER.name())
                             .anyRequest().authenticated();
                 })
 //                .authorizeRequests()//URL별 권한 관리를 설정하는 옵션의 시작점

--- a/src/main/java/com/study/blog/domain/Users.java
+++ b/src/main/java/com/study/blog/domain/Users.java
@@ -1,14 +1,12 @@
 package com.study.blog.domain;
 import com.study.blog.oauth2.Role;
 import com.study.blog.oauth2.SocialType;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 @Getter
 @Setter
 @NoArgsConstructor
+@ToString
 public class Users {
     private Long id;
     private String email;

--- a/src/main/java/com/study/blog/domain/comment/CommentRequest.java
+++ b/src/main/java/com/study/blog/domain/comment/CommentRequest.java
@@ -1,11 +1,11 @@
 package com.study.blog.domain.comment;
 
-import lombok.Builder;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 
 @Getter
 @Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@ToString
 public class CommentRequest {
     private Long id;
     private Long postId;

--- a/src/main/java/com/study/blog/domain/comment/CommentResponse.java
+++ b/src/main/java/com/study/blog/domain/comment/CommentResponse.java
@@ -1,18 +1,18 @@
 package com.study.blog.domain.comment;
 
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import com.study.blog.domain.Users;
+import lombok.*;
 
 import java.time.LocalDateTime;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@ToString
 public class CommentResponse {
     private Long id;
     private Long postId;
     private String content;
-    private Long userId;
+    private Users user;
     private LocalDateTime createdDate;
     private LocalDateTime modifiedDate;
     private Long parentId; //댓글의 그룹을 확인하는 용으로, 댓글 그룹의 부모 PK를 가지게 된다.

--- a/src/main/java/com/study/blog/dto/SessionUser.java
+++ b/src/main/java/com/study/blog/dto/SessionUser.java
@@ -6,10 +6,12 @@ import lombok.Getter;
 
 @Getter
 public class SessionUser {
+    private final Long id; //db상의 유저 pk
     private final String nickname;
     private final String image;
 
     public SessionUser(Users user) {
+        this.id = user.getId();
         this.nickname = user.getNickname();
         this.image = user.getImageUrl();
     }

--- a/src/main/java/com/study/blog/mapper/CommentMapper.java
+++ b/src/main/java/com/study/blog/mapper/CommentMapper.java
@@ -12,7 +12,7 @@ import java.util.List;
 public interface CommentMapper {
     void save(CommentRequest commentRequest);
 
-    List<CommentResponse> findComments();
+    List<CommentResponse> findComments(Long postId);
 
     List<CommentResponse> findReplies(Long id);
 
@@ -22,6 +22,8 @@ public interface CommentMapper {
     @Delete("delete from comment where id=#{id}")
     void delete(Long id);
 
-    @Update("update comment set content = #{content} where id = #{id}")
+    @Update("update comment set content = #{content}, modified_date = now() where id = #{id}")
     void update(CommentRequest commentRequest);
+
+    CommentResponse findOne(Long commentId);
 }

--- a/src/main/java/com/study/blog/restapi/CommentController.java
+++ b/src/main/java/com/study/blog/restapi/CommentController.java
@@ -1,0 +1,73 @@
+package com.study.blog.restapi;
+
+import com.study.blog.domain.comment.CommentRequest;
+import com.study.blog.domain.comment.CommentResponse;
+import com.study.blog.service.CommentService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+public class CommentController {
+    private final CommentService commentService;
+
+    @GetMapping("/posts/{postId}/comments") //댓글 조회
+    public List<CommentResponse> findAllComments(
+            @PathVariable final Long postId){
+        return commentService.findComments(postId);
+    }
+
+    @GetMapping("/posts/{postId}/comments/{commentId}")
+    public CommentResponse findOneComment( //댓글 하나 조회
+            @PathVariable final Long postId,
+            @PathVariable final Long commentId) {
+        return commentService.findOne(commentId);
+    }
+
+
+    @PostMapping("/posts/{postId}/comments") //신규 댓글 저장
+    public Map<String,Object> saveComment(
+            @PathVariable final Long postId,
+            @RequestBody final CommentRequest commentRequest) {
+        log.info("CommentController.saveComment() => 파라미터 : "+ commentRequest.toString());
+        Map<String,Object> response = new HashMap<>();
+        commentService.save(commentRequest);
+        response.put("msg","댓글이 저장되었습니다.");
+        return response;
+    }
+
+    @PatchMapping("/posts/{postId}/comments/{id}")
+    public Map<String,Object> updateComment( //댓글 수정
+            @PathVariable final Long postId,
+            @PathVariable final Long id,
+            @RequestBody final CommentRequest commentRequest) {
+        commentService.update(commentRequest);
+        Map<String,Object> response = new HashMap<>();
+        response.put("msg","댓글이 수정되었습니다.");
+        return response;
+    }
+
+    //댓글 삭제
+    @DeleteMapping("/posts/{postId}/comments/{id}")
+    public Map<String,Object> deleteComment(@PathVariable final Long postId,
+                                            @PathVariable final Long id) {
+        Map<String,Object> response = new HashMap<>();
+        try {
+            commentService.delete(id);
+        } catch (Exception e) {
+            response.put("msg",e.getMessage());
+            return response;
+        }
+        response.put("msg","댓글이 삭제되었습니다.");
+        return response;
+    }
+
+
+
+}

--- a/src/main/java/com/study/blog/service/CommentService.java
+++ b/src/main/java/com/study/blog/service/CommentService.java
@@ -17,8 +17,8 @@ public class CommentService {
         return commentRequest.getId();
     }
 
-    public List<CommentResponse> findComments() {
-        return commentMapper.findComments();
+    public List<CommentResponse> findComments(Long postId) {
+        return commentMapper.findComments(postId);
     }
 
     public List<CommentResponse> findReplies(final Long id) {
@@ -35,5 +35,9 @@ public class CommentService {
 
     public void update(final CommentRequest commentRequest) {
         commentMapper.update(commentRequest);
+    }
+
+    public CommentResponse findOne(Long commentId) {
+        return commentMapper.findOne(commentId);
     }
 }

--- a/src/main/resources/mybatis/mapper/comment-mapper.xml
+++ b/src/main/resources/mybatis/mapper/comment-mapper.xml
@@ -6,10 +6,97 @@
         VALUES (#{postId},#{content},#{userId},NOW(),null,#{parentId},#{depth})
     </insert>
 
-    <select id="findComments" resultType="CommentResponse">
-        select * from comment where depth = 1 order by id
+    <select id="findComments" parameterType="Long" resultMap="CommentWithUser">
+        WITH RECURSIVE CTE AS (
+            SELECT id, post_id, content, user_id, created_date, modified_date, parent_id,depth, convert(id, char) as path
+            FROM comment
+            WHERE comment.parent_id = 0
+              AND post_id = #{postId}
+            UNION ALL
+            SELECT uc.id, uc.post_id, uc.content, uc.user_id, uc.created_date, uc.modified_date, uc.parent_id, uc.depth, concat(CTE.id, '-', uc.id) AS path
+            FROM comment uc
+                     INNER JOIN CTE ON uc.parent_id = CTE.id
+            WHERE uc.post_id = #{postId}
+        )
+        SELECT
+            c.id as id,
+            c.post_id as post_id,
+            c.content as content,
+            c.created_date as created_date,
+            c.modified_date as modified_date,
+            c.parent_id as parent_id,
+            c.depth as depth,
+            u.id as u_id,
+            u.email as u_email,
+            u.role as u_role,
+            u.social_type as u_social_type,
+            u.social_id as u_social_id,
+            u.nickname as u_nickname,
+            u.image_url as u_image_url
+        FROM CTE as c inner join users u on c.user_id = u.id
+        ORDER BY CONVERT(SUBSTRING_INDEX(path, '-', 1), UNSIGNED) ASC, id ASC, CONVERT(SUBSTRING_INDEX(path, '-', 2), UNSIGNED) ASC, id ASC;
     </select>
     <select id="findReplies" parameterType="Long" resultType="CommentResponse">
-        select * from comment where parent_id = #{id} and depth = 2 order by created_date
+        select
+            c.id as id,
+            c.post_id as post_id,
+            c.content as content,
+            c.created_date as created_date,
+            c.modified_date as modified_date,
+            c.parent_id as parent_id,
+            c.depth as depth,
+            u.id as u_id,
+            u.email as u_email,
+            u.role as u_role,
+            u.social_type as u_social_type,
+            u.social_id as u_social_id,
+            u.nickname as u_nickname,
+            u.image_url as u_image_url
+        from comment as c inner join users u
+            on c.user_id = u.id
+        where parent_id = #{id} and depth = 2 order by created_date
     </select>
+
+    <select id="findOne" parameterType="Long" resultMap="CommentWithUser">
+        select
+            c.id as id,
+            c.post_id as post_id,
+            c.content as content,
+            c.created_date as created_date,
+            c.modified_date as modified_date,
+            c.parent_id as parent_id,
+            c.depth as depth,
+            u.id as u_id,
+            u.email as u_email,
+            u.role as u_role,
+            u.social_type as u_social_type,
+            u.social_id as u_social_id,
+            u.nickname as u_nickname,
+            u.image_url as u_image_url
+        from comment as c inner join users u
+                                     on c.user_id = u.id
+        where c.id = #{commentId}
+    </select>
+
+
+    <resultMap id="CommentWithUser" type="CommentResponse">
+        <id property="id" column="id"/>
+        <result property="postId" column="post_id"/>
+        <result property="content" column="content"/>
+        <result property="createdDate" column="created_date"/>
+        <result property="modifiedDate" column="modified_date"/>
+        <result property="parentId" column="parent_id"/>
+        <result property="depth" column="depth"/>
+        <association property="user" resultMap="UserBase" columnPrefix="u_"/>
+    </resultMap>
+
+    <resultMap id="UserBase" type="Users">
+        <id property="id" column="id"/>
+        <result property="email" column="email"/>
+        <result property="role" column="role"/>
+        <result property="socialType" column="social_type"/>
+        <result property="socialId" column="social_id"/>
+        <result property="nickname" column="nickname"/>
+        <result property="imageUrl" column="image_url"/>
+    </resultMap>
 </mapper>

--- a/src/main/resources/templates/fragments/body.html
+++ b/src/main/resources/templates/fragments/body.html
@@ -8,10 +8,8 @@
     <nav class="navbar navbar-expand-lg navbar-light bg-white fixed-top">
         <div class="container-fluid">
             <!-- Navbar brand -->
-            <a class="navbar-brand" target="_blank" href="/post">
-                <img src="https://mdbootstrap.com/img/logo/mdb-transaprent-noshadows.png" height="16" alt=""
-                     loading="lazy"
-                     style="margin-top: -3px;"/>
+            <a class="navbar-brand" href="/post">
+                JH BLOG
             </a>
             <button class="navbar-toggler" type="button" data-mdb-toggle="collapse" data-mdb-target="#navbarExample01"
                     aria-controls="navbarExample01" aria-expanded="false" aria-label="Toggle navigation">
@@ -19,13 +17,6 @@
             </button>
             <div class="collapse navbar-collapse" id="navbarExample01">
                 <ul class="navbar-nav me-auto mb-2 mb-lg-0">
-                    <li class="nav-item active">
-                        <a class="nav-link" aria-current="page" href="#intro">개발 공부</a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link" href="#" rel="nofollow"
-                           target="_blank">일상</a>
-                    </li>
                 </ul>
 
                 <ul class="navbar-nav d-flex flex-row">

--- a/src/main/resources/templates/post/main.html
+++ b/src/main/resources/templates/post/main.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="ko" xmlns:th="http://www.thymeleaf.org"
       xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      xmlns:sec="http://www.thymeleaf.org/extras/spring-security"
       layout:decorate="~{layout/BlogLayout}">
 <th:block layout:fragment="title">
     <title>블로그 메인</title>
@@ -65,7 +66,7 @@
                 </form>
 
                 <!-- 글 쓰기 버튼 -->
-                <p class="my-1 d-flex flex-row-reverse"><a th:href="@{/post/write}" class="btn btn-outline-info">글쓰기</a>
+                <p sec:authorize="hasRole('ROLE_USER')" class="my-1 d-flex flex-row-reverse"><a th:href="@{/post/write}" class="btn btn-outline-info">글쓰기</a>
                 </p>
                 <section>
                     <!-- Post -->

--- a/src/main/resources/templates/post/view.html
+++ b/src/main/resources/templates/post/view.html
@@ -1,20 +1,23 @@
 <!DOCTYPE html>
 <html lang="ko" xmlns:th="http://www.thymeleaf.org"
       xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      xmlns:sec="http://www.thymeleaf.org/extras/spring-security"
       layout:decorate="~{layout/BlogLayout}">
 <th:block layout:fragment="title">
     <title th:text="${post.title}"></title>
 </th:block>
 <th:block layout:fragment="add-css">
     <!-- Toast Ui -->
-    <link rel="stylesheet" href="https://uicdn.toast.com/editor/latest/toastui-editor.min.css" />
+    <link rel="stylesheet" href="https://uicdn.toast.com/editor/latest/toastui-editor.min.css"/>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.23.0/themes/prism.min.css"/>
-    <link rel="stylesheet" href="https://uicdn.toast.com/editor-plugin-code-syntax-highlight/latest/toastui-editor-plugin-code-syntax-highlight.min.css"/>
+    <link rel="stylesheet"
+          href="https://uicdn.toast.com/editor-plugin-code-syntax-highlight/latest/toastui-editor-plugin-code-syntax-highlight.min.css"/>
     <link rel="stylesheet" href="https://uicdn.toast.com/tui-color-picker/latest/tui-color-picker.min.css"/>
-    <link rel="stylesheet" href="https://uicdn.toast.com/editor-plugin-color-syntax/latest/toastui-editor-plugin-color-syntax.min.css"/>
+    <link rel="stylesheet"
+          href="https://uicdn.toast.com/editor-plugin-color-syntax/latest/toastui-editor-plugin-color-syntax.min.css"/>
     <style>
         tags.tagify {
-            border : none;
+            border: none;
         }
     </style>
 </th:block>
@@ -23,7 +26,8 @@
         <h1 class="text-center" th:text="${post.title}"></h1>
         <div class="d-flex flex-column gap-2 mt-4">
             <p class="d-flex align-items-center">
-                <span class="fw-bold me-1">정현 ·</span><span style="font-size: 13px" th:text="${#temporals.format(post.createdDate,'yyyy년 M월 d일 HH시 mm분')}"></span>
+                <span class="fw-bold me-1">정현 ·</span><span style="font-size: 13px"
+                                                            th:text="${#temporals.format(post.createdDate,'yyyy년 M월 d일 HH시 mm분')}"></span>
             </p>
         </div>
         <div class="mb-5">
@@ -33,8 +37,57 @@
         <div id="viewer"></div>
         <div class="d-flex gap-3 mt-4">
             <button type="button" onclick="goListPage();" class="btn btn-secondary me-auto">뒤로</button>
-            <button type="button" onclick="goWritePage();" class="btn btn-primary">수정</button>
-            <button type="button" onclick="deletePost();" class="btn btn-danger">삭제</button>
+            <button sec:authorize="hasRole('ROLE_USER')" type="button" onclick="goWritePage();" class="btn btn-primary">수정</button>
+            <button sec:authorize="hasRole('ROLE_USER')" type="button" onclick="deletePost();" class="btn btn-danger">삭제</button>
+        </div>
+    </section>
+    <!-- 댓글 모달 -->
+    <div class="modal fade" id="commentUpdateModal" tabindex="-1" aria-labelledby="commentUpdateModal" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title" id="exampleModalLabel">댓글 수정</h5>
+                    <button type="button" class="btn-close" data-mdb-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    <div class="row">
+                        <div class="col">
+                            <div class="d-flex flex-row align-items-center gap-2 mb-1" style="height:30px">
+                                <input type="hidden" id="modalWriter" name="userId" th:value="${session.user != null} ? ${session.user.id} : ''"/>
+                                <img th:src="${session.user != null} ? ${session.user.image} : ''" style="max-height: 30px" class="img-fluid rounded-9" alt="프로필"/>
+                                <span class="text-center" th:text="${session.user != null} ? ${session.user.nickname} : ''"></span>
+                            </div>
+                            <textarea class="w-100" id="modalContent" name="content" onkeyup="countingModalLength(this);"
+                                      rows="4" placeholder="댓글을 입력해 주세요."></textarea>
+                            <div class="d-flex">
+                                <i id="modalCounter" class="me-auto text-muted">0/300자</i>
+                                <button id="commentUpdateBtn" type="button" class="btn btn-black">수정</button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <section> <!-- 댓글 영역 -->
+        <!-- 댓글 렌더링 영역 -->
+        <div class="cm_list d-flex flex-column gap-1">
+
+        </div>
+        <div class="row">
+            <div class="col">
+                <div class="d-flex flex-row align-items-center gap-2 mb-1" style="height:30px">
+                    <input type="hidden" id="writerId" name="writerId" th:value="${session.user != null} ? ${session.user.id} : ''"/>
+                    <img th:src="${session.user != null} ? ${session.user.image} : ''" style="max-height: 30px" class="img-fluid rounded-9" alt="프로필"/>
+                    <span class="text-center" th:text="${session.user != null} ? ${session.user.nickname} : ''"></span>
+                </div>
+                <textarea class="w-100" id="content" name="content" onkeyup="countingLength(this);"
+                          rows="4" placeholder="댓글을 입력해 주세요."></textarea>
+                <div class="d-flex">
+                    <i id="counter" class="me-auto text-muted">0/300자</i>
+                    <button type="button" class="btn btn-black" onclick="saveComment();">등 록</button>
+                </div>
+            </div>
         </div>
     </section>
 </th:block>
@@ -48,10 +101,11 @@
     <script src="https://uicdn.toast.com/editor-plugin-color-syntax/latest/toastui-editor-plugin-color-syntax.min.js"></script>
     <script th:inline="javascript">
         /*<![CDATA[*/
-        const { Editor } = toastui;
-        const { codeSyntaxHighlight, colorSyntax } = Editor.plugin;
+        const {Editor} = toastui;
+        const {codeSyntaxHighlight, colorSyntax} = Editor.plugin;
         window.onload = () => {
             createContent();
+            findAllComment();
         }
 
         // 해시태그 라이브러리 Tagify 사용
@@ -76,7 +130,7 @@
 
         function deletePost() {
             const id = [[${post.id}]];
-            if(!confirm(id +'번 포스트를 삭제할까요?')) {
+            if (!confirm(id + '번 포스트를 삭제할까요?')) {
                 return false;
             }
             let inputHtml = '';
@@ -98,6 +152,169 @@
             const queryString = new URLSearchParams(location.search);
             queryString.delete('id');
             location.href = '/post' + '?' + queryString.toString();
+        }
+
+        // 전체 댓글 조회
+        function findAllComment() {
+            const postId = [[${post.id}]];
+            const uri = `/posts/${postId}/comments`;
+            const commentList = callApi(uri,'','get');
+            drawComments(commentList);
+        }
+        // uri 와 데이터를 보내면 요청을 get방식으로 전송하는 함수
+        function callApi(uri, params,type) {
+            let json = {}
+            $.ajax({
+                url : uri,
+                type: type,
+                dataType : 'json',
+                contentType: 'application/json; charset=utf-8',
+                data : JSON.stringify(params),
+                async : false,
+                success : function (response) {
+                    json = response;
+                },
+                error : function () {
+                    console.log('비동기 통신 에러')
+                }
+            });
+            return json;
+        }
+
+        // 댓글 HTML draw
+        function drawComments(list) {
+            console.log(list)
+            if (!list.length) {
+                document.querySelector('.cm_list').innerHTML = '<div><p>등록된 댓글이 없습니다.</p></div>';
+                return false;
+            }
+
+            let commentHtml = '';
+            let sessionId = [[${session.user.id}]];
+            list.forEach(row => {
+                commentHtml += `
+                <div class="${row.depth === 2 ? 'ms-5' : ''}">
+                <div class="d-flex flex-row gap-2 align-items-center">`
+                commentHtml+= (row.depth === 2) ? `<i class="fa-solid fa-arrow-turn-up fa-rotate-90"></i>` : '';
+                commentHtml+= `
+                    <img src="${row.user.imageUrl}" class="img-fluid rounded-9" width="30" height="30" alt="기본 프로필 이미지"/>
+                    <span class="me-auto">${row.user.nickname}</span>
+                    <span class="text-muted" style="font-size:12px;">${dayjs(row.createdDate).format('YYYY-MM-DD HH:mm')}</span>
+                </div>
+                <div class="ms-4 mt-2 d-flex flex-row">
+                    <p class="me-auto">${row.content}</p>`;
+                commentHtml += (sessionId === row.user.id) ?`
+                    <div class="btn-group-sm d-flex">
+                        <button type="button" onclick="openModal(${row.id})" class="btn btn-outline-secondary">수정</button>
+                        <button type="button" onclick="deleteComment(${row.id})" class="btn btn-outline-secondary">삭제</button>
+                    </div></div></div>`:`<div><button type="button" onclick="openReplyModal(${row.id})" class="btn btn-outline-secondary">답글달기</button> </div></div></div>`;
+            })
+            document.querySelector('.cm_list').innerHTML = commentHtml;
+        }
+
+        function countingLength(content) {
+            if (content.value.length > 300) {
+                alert('댓글을 300자 이하로 입력해 주세요.');
+                content.value = content.value.substring(0, 300);
+                content.focus();
+            }
+            document.getElementById('counter').innerText = content.value.length + '/300자';
+        }
+        function countingModalLength(content) {
+            if (content.value.length > 300) {
+                alert('댓글을 300자 이하로 입력해 주세요.');
+                content.value = content.value.substring(0, 300);
+                content.focus();
+            }
+            document.getElementById('modalCounter').innerText = content.value.length + '/300자';
+        }
+
+        function saveComment() {
+            const content = document.getElementById('content');
+            if(content.value.length === 0) {
+                alert("내용을 입력해주세요.");
+                content.focus();
+                return false;
+            }
+
+            const postId = [[${post.id}]];
+            const writer = document.getElementById('writerId').value;
+            const params = {
+                postId: postId,
+                content: content.value,
+                userId: writer,
+                parentId : 0,
+                depth : 1
+            }
+            const uri = `/posts/${postId}/comments`;
+            const response = callApi(uri, params,'post');
+            alert(response.msg);
+            content.value = '';
+            document.getElementById('counter').innerText = '0/300자';
+            findAllComment(); //댓글 입력 후 댓글의 1페이지를 봐야함
+        }
+
+        function deleteComment(commentId) {
+            const postId = [[${post.id}]];
+            const uri = `/posts/${postId}/comments/${commentId}`;
+            const response = callApi(uri,"",'delete');
+            alert(response.msg);
+            findAllComment();
+        }
+
+        function openModal(id) {
+            const postId = [[${post.id}]];
+            const uri = `/posts/${postId}/comments/${id}`;
+            const response = callApi(uri,"",'get');
+            document.getElementById('modalContent').value = response.content;
+            document.getElementById('commentUpdateBtn').setAttribute('onclick',`updateComment(${id})`);
+            $('#commentUpdateModal').modal('show');
+        }
+
+        function openReplyModal(id) {
+            document.querySelector('.modal-title').innerText = '답글 달기';
+            let commentModalBtn = document.getElementById('commentUpdateBtn');
+            commentModalBtn.setAttribute('onclick',`saveReply(${id})`);
+            commentModalBtn.innerText = '저장';
+            $('#commentUpdateModal').modal('show');
+        }
+
+        function saveReply(id) {
+            const postId = [[${post.id}]];
+            const uri = `/posts/${postId}/comments`;
+            const content = document.getElementById('modalContent').value;
+            const userId = document.getElementById('modalWriter').value;
+            const params = {
+                postId: postId,
+                content: content,
+                userId: userId,
+                parentId : id,
+                depth : 2
+            }
+            let response = callApi(uri,params,'post');
+            alert(response.msg);
+            $('#commentUpdateModal').modal('hide')
+            findAllComment();
+        }
+
+        function updateComment(id) {
+            let modalContent = document.getElementById('modalContent');
+            if(modalContent.value.length === 0) {
+                alert("내용을 입력해주세요.")
+                modalContent.focus();
+                return false;
+            }
+            const postId = [[${post.id}]];
+            const uri = `/posts/${postId}/comments/${id}`
+            const params = {
+                id : id,
+                postId : postId,
+                content : modalContent.value
+            }
+            let response = callApi(uri,params,'patch');
+            alert(response.msg)
+            $('#commentUpdateModal').modal('hide')
+            findAllComment();
         }
         /*]]>*/
     </script>

--- a/src/test/java/com/study/blog/service/CommentServiceTest.java
+++ b/src/test/java/com/study/blog/service/CommentServiceTest.java
@@ -19,11 +19,11 @@ class CommentServiceTest {
     @DisplayName("댓글을 저장한다.")
     public void saveComment() throws Exception {
         //given
-        CommentRequest commentRequest = CommentRequest.builder().postId(13L).content("댓글1")
+        CommentRequest commentRequest = CommentRequest.builder().postId(13L).content("댓글3")
                                         .userId(3L).parentId(0L).depth(1).build();
         //when
         Long savedId = commentService.save(commentRequest);
-        List<CommentResponse> comments = commentService.findComments();
+        List<CommentResponse> comments = commentService.findComments(13L);
 
         //then
         comments.stream().filter((comment)-> comment.getId().equals(savedId)).findFirst()
@@ -34,8 +34,8 @@ class CommentServiceTest {
     @DisplayName("대댓글을 저장한다.")
     public void saveReply() throws Exception {
         //given
-        CommentRequest commentRequest = CommentRequest.builder().postId(13L).content("댓글1의 대댓글")
-                .userId(3L).parentId(2L).depth(2).build();
+        CommentRequest commentRequest = CommentRequest.builder().postId(13L).content("댓글3의 1")
+                .userId(3L).parentId(6L).depth(2).build();
         //when
         Long savedId = commentService.save(commentRequest);
         List<CommentResponse> comments = commentService.findReplies(2L);
@@ -44,4 +44,13 @@ class CommentServiceTest {
             System.out.println(comment.getContent());
         }
      }
+
+     @Test
+     @DisplayName("모든 댓글을 조회하면 댓글의 정보와 회원의 정보도 나와야한다.")
+     public void findComments() throws Exception {
+         List<CommentResponse> comments = commentService.findComments(13L);
+         for (CommentResponse comment : comments) {
+             System.out.println("comment.toString() = " + comment.toString());
+         }
+      }
 }


### PR DESCRIPTION
this closes #24 
댓글과 대댓글의 계층관계를 표현하기 위해 parent_id, depth 두 컬럼이 필요하다.
```sql
with recursive CTE as (
    select id, post_id, content, created_date, modified_date, parent_id, depth, convert(id,char) as path
    from comment where post_id = 13 and parent_id = 0
    union all
    select c.id, c.post_id, c.content, c.created_date, c.modified_date, c.parent_id, c.depth, concat(CTE.id,'-',c.id)as path
    from comment as c inner join CTE on c.parent_id = CTE.id
    where c.post_id = 13
)
select id, post_id, content, created_date, modified_date, parent_id, depth, path from CTE
order by substring_index(path,'-',1), substring_index(path,'-',2)
```
재귀쿼리는 with recursive 로 시작한다.
union(all)은 필수로 들어가야 하며, union all 절 앞의 select 문이 초기 한번만 실행되는 select 문이다.
그 이후론 union all 이후의 select 절이 반복되며, 계산으로 이어가는 반복의 경우엔 멈출 where 조건절이 필수라고 한다.
union all 절 앞의 쿼리가 부모댓글이고 뒤가 자식댓글이다. 이 계층관계에서 정렬을 수행하기 위해 path 컬럼을 추가해줬다.
1
- 1-1
- 1-2 
이런 댓글 구조라고 한다면 path에 1, 1-1, 1-2 이런식으로 id값을 기준으로 만들어준다.
부모, 자식관계를 지어주기 위해 inner join 의 on절에 `c.parent_id = CTE.id` 로 잡아줬다.
