### PR TITLE
권한 관련 에러페이지 정보 전달

### DIFF
--- a/src/main/java/com/study/blog/controller/MyErrorController.java
+++ b/src/main/java/com/study/blog/controller/MyErrorController.java
@@ -1,9 +1,11 @@
 package com.study.blog.controller;
 
+import com.study.blog.domain.ErrorStatus;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.web.servlet.error.ErrorController;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 import javax.servlet.RequestDispatcher;
@@ -13,7 +15,7 @@ import javax.servlet.http.HttpServletRequest;
 @Slf4j
 public class MyErrorController implements ErrorController {
     @RequestMapping("/error")
-    public String handleError(HttpServletRequest request) {
+    public String handleError(HttpServletRequest request, Model model) {
         Object status = request.getAttribute(RequestDispatcher.ERROR_STATUS_CODE);
 
         if (status != null) {
@@ -29,6 +31,20 @@ public class MyErrorController implements ErrorController {
                 return "error/500";
             }
         }
+        String codeStr = request.getParameter("code");
+        codeToReason(codeStr,model);
         return "error/404";
+    }
+
+    private void codeToReason(String codeStr, Model model) {
+        if(codeStr != null) {
+            Integer code = Integer.valueOf(codeStr);
+            if(code == ErrorStatus.NotFoundPost.getCode()) {
+                model.addAttribute("reason",ErrorStatus.NotFoundPost.getReason());
+            } else if(code == ErrorStatus.NotAuthorize.getCode()) {
+                model.addAttribute("reason", ErrorStatus.NotAuthorize.getReason());
+            }
+        }
+
     }
 }

--- a/src/main/java/com/study/blog/controller/PostController.java
+++ b/src/main/java/com/study/blog/controller/PostController.java
@@ -1,5 +1,6 @@
 package com.study.blog.controller;
 
+import com.study.blog.domain.ErrorStatus;
 import com.study.blog.domain.post.PostRequest;
 import com.study.blog.domain.post.PostResponse;
 import com.study.blog.dto.SearchDto;
@@ -78,6 +79,9 @@ public class PostController {
     public String viewPost(@RequestParam("id") final Long id,
                            Model model) {
         PostResponse findPost = postService.findPostById(id);
+        if(findPost == null ||findPost.getDeleteYn()) {
+            return "redirect:/error?code="+ ErrorStatus.NotFoundPost.getCode();
+        }
         model.addAttribute("post", findPost);
         model.addAttribute("hashtags", postTagMapper.findNameByPostId(id));
         return "post/view";

--- a/src/main/java/com/study/blog/domain/ErrorStatus.java
+++ b/src/main/java/com/study/blog/domain/ErrorStatus.java
@@ -1,0 +1,16 @@
+package com.study.blog.domain;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorStatus {
+    NotFoundPost(1,"해당 포스트를 찾을 수 없습니다."),
+    NotAuthorize(2,"해당 요청에 접근할 수 있는 권한이 없습니다.");
+
+    private final int code;
+
+    private final String reason;
+
+
+}

--- a/src/main/java/com/study/blog/interceptor/AuthCheckInterceptor.java
+++ b/src/main/java/com/study/blog/interceptor/AuthCheckInterceptor.java
@@ -1,5 +1,6 @@
 package com.study.blog.interceptor;
 
+import com.study.blog.domain.ErrorStatus;
 import com.study.blog.domain.Role;
 import com.study.blog.dto.SessionUser;
 import org.springframework.web.servlet.HandlerInterceptor;
@@ -12,9 +13,9 @@ public class AuthCheckInterceptor implements HandlerInterceptor {
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
         SessionUser user = (SessionUser) request.getSession().getAttribute("user");
         if(user == null || user.getRole() != Role.USER) {
-            response.sendRedirect("/post");
+            response.sendRedirect("/error?code=" + ErrorStatus.NotAuthorize.getCode());
             return false;
         }
-        return HandlerInterceptor.super.preHandle(request, response, handler);
+        return true;
     }
 }

--- a/src/main/resources/templates/error/404.html
+++ b/src/main/resources/templates/error/404.html
@@ -4,7 +4,8 @@
       layout:decorate="~{layout/BlogLayout}">
 <th:block layout:fragment="content">
     <div class="text-center mt-5">
-        <h1> 원하는 페이지를 찾을 수 없습니다. </h1>
+        <h1 th:if="${reason == null}"> 원하는 페이지를 찾을 수 없습니다. </h1>
+        <h1 th:if="${reason != null}" th:text="${reason}"> 에러메세지 </h1>
         <img src="https://jhblogimage.s3.ap-northeast-2.amazonaws.com/images/error404.png" alt="에러이미지">
         <h2> 메인화면으로 이동하세요! </h2>
         <a href="/post" class="btn btn-outline-secondary mt-3">홈으로</a>


### PR DESCRIPTION
this closes #37 
기존 에러 페이지는 정적인 페이지의 느낌이였다. 
사용자에게 에러에 대한 정보를 주기 위해 Enum을 추가하였다.

나중에 많아질 오류 코드에 대한 값을 정의해서 사용하기 위해 `ErrorStatus` 를 만들고 각 코드와 이유를 부여해 특정 범위의 값만 사용 가능하게 열거형으로 만들었다. 

# Enum 정리
- Type Safety
  - enum은 컴파일 타임에 **타입 안전성** 을 보장한다. 특정 범위의 값만 사용 가능하므로 컴파일 오류나 런타임 예외를 줄일 수 있다.
- ReadAbility
  - enum은 의도적으로 가독성이 높습니다. 값들이 명시적으로 정의되어 있기 때문에 코드를 읽을 때 쉽게 이해할 수 있습니다.
- MaintainAbility
  - enum은 관리가 용이하다. 값이 추가되거나 변경되는 경우, 한 곳에서만 변경하면 되기 때문에 코드의 유지 보수가 용이합니다.
- Performance
  - enum은 컴파일 타임에 정적인 값으로 변환되기 때문에, 실행 시간에서 상수 검색의 오버헤드를 줄입니다.
- 직렬화 : 싱글톤 보장
  - enum 타입은 기본적으로 직렬화 가능하므로 Serializable 인터페이스를 구현할 필요가 없고, 리플렉션 문제도 발생하지 않는다.

**인스턴스가 JVM내에 하나만 존재한다** 는 것이 100% 보장되므로, Java에서 싱글톤을 만드는 가장 좋은 방법으로 권장됩니다.

> Enum 값 비교는 그래서 equals() 가 아닌 == 으로 하는것이다. JVM 내에 하나의 인스턴스로 싱글톤이 보장되기 때문이다.

